### PR TITLE
fix class name of sensors

### DIFF
--- a/EnOcean/sensor-itec-ct.js
+++ b/EnOcean/sensor-itec-ct.js
@@ -1,6 +1,6 @@
 const SensorInterface = require('./sensors-interface');
 
-module.exports = class WattyTemperature extends SensorInterface {
+module.exports = class itecCT extends SensorInterface {
     /**
      * 電流計算.
      */

--- a/EnOcean/sensor-urd-ac.js
+++ b/EnOcean/sensor-urd-ac.js
@@ -1,6 +1,6 @@
 const SensorInterface = require('./sensors-interface');
 
-module.exports = class WattyTemperature extends SensorInterface {
+module.exports = class urdAC extends SensorInterface {
     /**
      * 電流計算.
      */


### PR DESCRIPTION
クラス名がWattyと被っており、この状態でNode-REDを再起動、sensors.jsを使用(下位classを呼び出し)すると、処理が落ちる場合があったので名称変更します。