### PR TITLE
Handling promise for SerialPort.list.

### DIFF
--- a/ia-cloud-serialport/ia-cloud-serialport.html
+++ b/ia-cloud-serialport/ia-cloud-serialport.html
@@ -176,12 +176,8 @@
                 $("#node-config-lookup-serial").addClass('disabled');
                 $.getJSON('serialports',function(data) {
                     $("#node-config-lookup-serial").removeClass('disabled');
-                    var ports = [];
-                    $.each(data, function(i, port) {
-                        ports.push(port.comName);
-                    });
                     $("#node-config-input-serialport").autocomplete({
-                        source:ports,
+                        source:data,
                         minLength:0,
                         close: function( event, ui ) {
                             $("#node-config-input-serialport").autocomplete( "destroy" );

--- a/ia-cloud-serialport/ia-cloud-serialport.js
+++ b/ia-cloud-serialport/ia-cloud-serialport.js
@@ -287,8 +287,14 @@ module.exports = function(RED) {
         }());
 
     RED.httpAdmin.get('/serialports', RED.auth.needsPermission('serial.read'), function(req, res) {
-        serialp.list(function (err, ports) {
-            res.json(ports);
-        });
+        serialp.list()
+            .then(function(data) {
+                // data = [{"path":"COM3","manufacturer":"FTDI","serialNumber":"FT2L5LDF","pnpId":"FTDIBUS\\VID_0403+PID_6001+FT2L5LDFA\\0000","vendorId":"0403","productId":"6001"}]
+                res.json(data.map(d => d.path));
+            })
+            .catch(function(err) {
+                console.error(err);
+                // res.json([RED._('serial.errors.list')]);
+            });
     });
 }

--- a/ia-cloud-serialport/ia-cloud-serialport.js
+++ b/ia-cloud-serialport/ia-cloud-serialport.js
@@ -286,7 +286,7 @@ module.exports = function(RED) {
             }
         }());
 
-    RED.httpAdmin.get("/serialports", RED.auth.needsPermission('serial.read'), function(req,res) {
+    RED.httpAdmin.get('/serialports', RED.auth.needsPermission('serial.read'), function(req, res) {
         serialp.list(function (err, ports) {
             res.json(ports);
         });


### PR DESCRIPTION
Details of error below.
UnhandledPromiseRejectionWarning: TypeError: SerialPort.list no longer takes a callback and only returns a promise
    at Function.SerialPort.list (C:\workspaces\node-red-contrib-ia-cloud-fds\node_modules\serialport\node_modules\@serialport\stream\lib\index.js:651:11)