### PR TITLE
HMI-Schneider: Replace websocket class from 'WebSocket-npm' to 'ws-npm'

### DIFF
--- a/HMI-Schneider/HMI-Schneider-Websocket.js
+++ b/HMI-Schneider/HMI-Schneider-Websocket.js
@@ -1,4 +1,10 @@
 
+//  definition of disconnect sec in idle.
+//  HMI will send ping every 10sec if there are any communication.
+//  And if HMI do not receive pong from client, disconnet session in 60sec.
+//  From the specification, if HMI is connected, websocket client should receive ping in every 10 sec.
+const websocket_disconnect_sec = 30;
+
 /* Pro-face BLUE/Schneider Electric EcoStruxure Operator Terminal Expart WebSocket class */
 module.exports = class HmiSchneiderWebSocket {
   constructor(id, alarm, error) {
@@ -51,7 +57,7 @@ module.exports = class HmiSchneiderWebSocket {
       return;
     }
 
-    var WebSocket = require('websocket').w3cwebsocket;
+    var WebSocket = require('ws');
 
     if (!this._ws) {
       if (url != undefined) {
@@ -69,6 +75,7 @@ module.exports = class HmiSchneiderWebSocket {
       this._ws.onmessage = this.onMessage.bind(this);
       this._ws.onclose = this.onClose.bind(this);
       this._ws.onerror = this.onError.bind(this);
+      this._ws.on('ping', this.onPing.bind(this));
     }
   }
 
@@ -81,7 +88,7 @@ module.exports = class HmiSchneiderWebSocket {
     this._status = this.en_status.en_none;
   }
 
-  onOpen(event) {
+  onOpen() {
     if (this._reconnect_id) {
       clearTimeout(this._reconnect_id);
       this._reconnect_id = null;
@@ -105,7 +112,7 @@ module.exports = class HmiSchneiderWebSocket {
     }
   }
 
-  onError(event) {
+  onError() {
     if (this._cb_onerror) {
       this._cb_onerror.call(this, this._id);
     }
@@ -113,7 +120,7 @@ module.exports = class HmiSchneiderWebSocket {
     this.close();
   }
 
-  onClose(event) {
+  onClose() {
     this._ws = null;
 
     this._status = this.en_status.en_none;
@@ -133,6 +140,10 @@ module.exports = class HmiSchneiderWebSocket {
     if (this._cb_onclose) {
       this._cb_onclose.call(this, this._id);
     }
+  }
+
+  onPing(data) {
+    this.update_received_date();
   }
 
   send_authorization() {
@@ -194,13 +205,12 @@ module.exports = class HmiSchneiderWebSocket {
   check_connection() {
     this._timer_id = null;
     if (this._ws) {
-      if (Date.now() - this._last_received > 10000) {
-        //  HMI will disconnect when there are any communication in 60 secs.
-        //  if 10sec is idle, send ping to HMI
-        this._ws._connection.ping();
-        this.update_received_date();
+      if ((Date.now() - this._last_received) > (websocket_disconnect_sec * 1000)) {
+        this.close();
       }
-      this._timer_id = setTimeout(this.check_connection.bind(this), 1000);
+      else {
+        this._timer_id = setTimeout(this.check_connection.bind(this), 1000);
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "serialport": "^9.0.0",
     "@serialport/parser-inter-byte-timeout": "^9.0.0",
     "@serialport/parser-delimiter": "^9.0.0",
-    "websocket": "^1.0.30",
     "ws": "^7.1.2",
     "got": "^11.5.2"
   },


### PR DESCRIPTION
使用しているWebSocketのクラスをwsに置き換えました。
wsではping/pongのハンドリングが可能であるため、断線時のハンドリングが仕様から論理的に実装可能になっています。

websocketを使用しているモジュールがなくなった為、package.jsonから削除しています。