### PR TITLE
EnOcean data length fix

### DIFF
--- a/EnOcean/EnOcean-com.js
+++ b/EnOcean/EnOcean-com.js
@@ -186,9 +186,9 @@ module.exports = function (RED) {
             dataDL = esp3RawData.substr(index, 6);
             index += 6;
         } else if (telegramType === 0b1111) { // EXT
-            if (extendedTelegramType === 0x07) { // In case of GP // 0x07: Generic Profiles Complete data (0xB2)
-                dataDL = esp3RawData.substr(index, 10);
-                index += 10;
+            if (extendedTelegramType === 0x07) { // EXTの場合は長さが一定でないため、残りのパラメータ全てを代入する
+                dataDL = esp3RawData.substr(index);
+                index = esp3RawData.length;
             }
         }
 

--- a/EnOcean/sensor-core-staff-temperature-humidity.js
+++ b/EnOcean/sensor-core-staff-temperature-humidity.js
@@ -21,13 +21,16 @@ module.exports = class CoreStaffTemperatureHumidity extends SensorInterface {
      * 温湿度計算.
      */
     static process(data) {
+        const dataLength = 8; // 4Byte * 2
+        // 処理に必要なデータ長を抽出
+        const fixedLengthData = data.replace('0x', '').slice(0, dataLength);
         const result = [];
-        if (data.length < 4 * 2) {
+        if (fixedLengthData.length < dataLength) {
             // 4Byte以上でなければ空リスト返却
             return result;
         }
         // 4Byteのデータ長のうち先頭2Byte目が湿度、3Byte目が温度
-        const dec = parseInt(data, 16);
+        const dec = parseInt(fixedLengthData, 16);
         // 湿度の抽出(2Byte目)
         const dec1 = (dec >> 16) & 0xFF;
         // 温度の抽出(3Byte目)

--- a/EnOcean/sensor-itec-ct.js
+++ b/EnOcean/sensor-itec-ct.js
@@ -21,12 +21,15 @@ module.exports = class itecCT extends SensorInterface {
      * 電流計算.
      */
     static process(data) {
+        const dataLength = 6; // 3Byte * 2
+        // 処理に必要なデータ長を抽出
+        const fixedLengthData = data.replace('0x', '').slice(0, dataLength);
         const result = [];
-        if (data.length < 3 * 2) {
+        if (fixedLengthData.length < dataLength) {
             // 3Byte以上でなければ空リスト返却
             return result;
         }
-        const dec = parseInt(data, 16);
+        const dec = parseInt(fixedLengthData, 16);
         const bin = `000000000000000000000000${dec.toString(2)}`.slice(-24); // 0パディング（24桁）
         // Divisor（先頭から2bit目)の値を取得する
         const div = parseInt(bin.substr(1, 1), 2);

--- a/EnOcean/sensor-optex-occupancy.js
+++ b/EnOcean/sensor-optex-occupancy.js
@@ -21,14 +21,17 @@ module.exports = class OptexOccupancy extends SensorInterface {
      * 在室センサーの状況取得.
      */
     static process(data) {
+        const dataLength = 8; // 4Byte * 2
+        // 処理に必要なデータ長を抽出
+        const fixedLengthData = data.replace('0x', '').slice(0, dataLength);
         const result = [];
-        if (data.length < 4 * 2) {
+        if (fixedLengthData.length < dataLength) {
             // 4Byte以上でなければ空リスト返却
             return result;
         }
 
         // 4Byteのデータ長のうち先頭1Byte目が供給電圧、3Byte目が在室状態
-        const dec = parseInt(data, 16);
+        const dec = parseInt(fixedLengthData, 16);
         // 供給電圧の抽出(1Byte目)
         const dec1 = (dec >> 24) & 0xFF;
         // 在室状態の抽出(3Byte目)

--- a/EnOcean/sensor-optex-rocker-switch.js
+++ b/EnOcean/sensor-optex-rocker-switch.js
@@ -21,12 +21,15 @@ module.exports = class OptexRockerSwitch extends SensorInterface {
      * ロッカースイッチの状況取得.
      */
     static process(data) {
+        const dataLength = 2; // 1Byte * 2
+        // 処理に必要なデータ長を抽出
+        const fixedLengthData = data.replace('0x', '').slice(0, dataLength);
         const result = [];
-        if (data.length < 2) {
+        if (fixedLengthData.length < dataLength) {
             // 1Byte以上でなければ空リスト返却
             return result;
         }
-        const dec = parseInt(data, 16);
+        const dec = parseInt(fixedLengthData, 16);
         const bin = `00000000${dec.toString(2)}`.slice(-8); // 0パディング（8桁）
         // State of the energy bow
         const ebo = parseInt(bin.substr(0, 1), 2);

--- a/EnOcean/sensor-watty-hyco.js
+++ b/EnOcean/sensor-watty-hyco.js
@@ -21,17 +21,18 @@ module.exports = class WattyHyco extends SensorInterface {
      * CO2濃度計算.
      */
     static process(data) {
-        // 16進数表記から0xを除外
-        const dataString = data.replace('0x', '');
+        const dataLength = 12; // 6Byte * 2
+        // 処理に必要なデータ長を抽出
+        const fixedLengthData = data.replace('0x', '').slice(0, dataLength);
         const ret = [];
-        if (dataString.length < 6 * 2) {
+        if (fixedLengthData.length < dataLength) {
             // 6Byte以上でなければ空リスト返却
             return ret;
         }
         // 0~3: CO2濃度, 4~7: 湿度, 8~11: 温度
-        const dec1 = parseInt(dataString.substr(0, 4), 16);
-        const dec2 = parseInt(dataString.substr(4, 4), 16);
-        const dec3 = parseInt(dataString.substr(8, 4), 16);
+        const dec1 = parseInt(fixedLengthData.substr(0, 4), 16);
+        const dec2 = parseInt(fixedLengthData.substr(4, 4), 16);
+        const dec3 = parseInt(fixedLengthData.substr(8, 4), 16);
         const paramList = [];
 
         // CO2濃度計算を行い、小数第4位を四捨五入して代入

--- a/EnOcean/sensor-watty-hyhq-ff.js
+++ b/EnOcean/sensor-watty-hyhq-ff.js
@@ -21,19 +21,20 @@ module.exports = class WattyHyhqFf extends SensorInterface {
      * 温度計算.
      */
     static process(data) {
-        // 16進数表記から0xを除外
-        const dataString = data.replace('0x', '');
+        const dataLength = 18; // 9Byte * 2
+        // 処理に必要なデータ長を抽出
+        const fixedLengthData = data.replace('0x', '').slice(0, dataLength);
         const ret = [];
-        if (dataString.length < 9 * 2) {
+        if (fixedLengthData.length < dataLength) {
             // 9Byte以上でなければ空リスト返却
             return ret;
         }
         // 0~3: 温度1, 4~7: 温度2, 8~11: 温度3, 12~15: 温度4, 16~17: 電圧
-        const dec1 = parseInt(dataString.substr(0, 4), 16);
-        const dec2 = parseInt(dataString.substr(4, 4), 16);
-        const dec3 = parseInt(dataString.substr(8, 4), 16);
-        const dec4 = parseInt(dataString.substr(12, 4), 16);
-        const dec5 = parseInt(dataString.substr(16, 2), 16);
+        const dec1 = parseInt(fixedLengthData.substr(0, 4), 16);
+        const dec2 = parseInt(fixedLengthData.substr(4, 4), 16);
+        const dec3 = parseInt(fixedLengthData.substr(8, 4), 16);
+        const dec4 = parseInt(fixedLengthData.substr(12, 4), 16);
+        const dec5 = parseInt(fixedLengthData.substr(16, 2), 16);
         const decList = [];
         decList.push(dec1);
         decList.push(dec2);

--- a/EnOcean/sensor-watty-hyhq.js
+++ b/EnOcean/sensor-watty-hyhq.js
@@ -21,16 +21,17 @@ module.exports = class WattyHyhq extends SensorInterface {
      * 温度計算.
      */
     static process(data) {
-        // 16進数表記から0xを除外
-        const dataString = data.replace('0x', '');
+        const dataLength = 8; // 4Byte * 2
+        // 処理に必要なデータ長を抽出
+        const fixedLengthData = data.replace('0x', '').slice(0, dataLength);
         const ret = [];
-        if (dataString.length < 4 * 2) {
+        if (fixedLengthData.length < dataLength) {
             // 4Byte以上でなければ空リスト返却
             return ret;
         }
         // 0~3: 温度1, 4~7: 温度2
-        const dec1 = parseInt(dataString.substr(0, 4), 16);
-        const dec2 = parseInt(dataString.substr(4, 4), 16);
+        const dec1 = parseInt(fixedLengthData.substr(0, 4), 16);
+        const dec2 = parseInt(fixedLengthData.substr(4, 4), 16);
         const decList = [];
         decList.push(dec1);
         decList.push(dec2);

--- a/EnOcean/sensor-watty-hyhu3.js
+++ b/EnOcean/sensor-watty-hyhu3.js
@@ -21,17 +21,18 @@ module.exports = class WattyThermoHum extends SensorInterface {
      * 温湿度計算.
      */
     static process(data) {
-        // 16進数表記から0xを除外
-        const dataString = data.replace('0x', '');
+        const dataLength = 10; // 5Byte * 2
+        // 処理に必要なデータ長を抽出
+        const fixedLengthData = data.replace('0x', '').slice(0, dataLength);
         const ret = [];
-        if (dataString.length < 5 * 2) {
+        if (fixedLengthData.length < dataLength) {
             // 5Byte以上でなければ空リスト返却
             return ret;
         }
         // 0~3: 湿度, 4~7: 温度, 8~9: 電圧
-        const dec1 = parseInt(dataString.substr(0, 4), 16);
-        const dec2 = parseInt(dataString.substr(4, 4), 16);
-        const dec3 = parseInt(dataString.substr(8, 2), 16);
+        const dec1 = parseInt(fixedLengthData.substr(0, 4), 16);
+        const dec2 = parseInt(fixedLengthData.substr(4, 4), 16);
+        const dec3 = parseInt(fixedLengthData.substr(8, 2), 16);
 
         const paramList = [];
         // 湿度計算を行い、小数第5位を四捨五入して代入

--- a/EnOcean/sensor-watty-hypm.js
+++ b/EnOcean/sensor-watty-hypm.js
@@ -21,18 +21,19 @@ module.exports = class WattyPm extends SensorInterface {
      * PM計算.
      */
     static process(data) {
-        // 16進数表記から0xを除外
-        const dataString = data.replace('0x', '');
+        const dataLength = 16; // 8Byte * 2
+        // 処理に必要なデータ長を抽出
+        const fixedLengthData = data.replace('0x', '').slice(0, dataLength);
         const ret = [];
-        if (dataString.length < 8 * 2) {
+        if (fixedLengthData.length < dataLength) {
             // 8Byte以上でなければ空リスト返却
             return ret;
         }
         // 0~3: PM1.0, 4~7: PM2.5, 8~11: PM4.0, 12~15: PM10.0
-        const dec1 = parseInt(dataString.substr(0, 4), 16);
-        const dec2 = parseInt(dataString.substr(4, 4), 16);
-        const dec3 = parseInt(dataString.substr(8, 4), 16);
-        const dec4 = parseInt(dataString.substr(12, 4), 16);
+        const dec1 = parseInt(fixedLengthData.substr(0, 4), 16);
+        const dec2 = parseInt(fixedLengthData.substr(4, 4), 16);
+        const dec3 = parseInt(fixedLengthData.substr(8, 4), 16);
+        const dec4 = parseInt(fixedLengthData.substr(12, 4), 16);
         const decList = [];
         decList.push(dec1);
         decList.push(dec2);

--- a/EnOcean/sensor-watty-temperature.js
+++ b/EnOcean/sensor-watty-temperature.js
@@ -21,14 +21,17 @@ module.exports = class WattyTemperature extends SensorInterface {
      * 温度計算.
      */
     static process(data) {
+        const dataLength = 10; // 5Byte * 2
         const ret = [];
-        if (data.length < 5 * 2) {
+        // 処理に必要なデータ長を抽出
+        const fixedLengthData = data.replace('0x', '').slice(0, dataLength);
+        if (fixedLengthData.length < dataLength) {
             // 5Byte以上でなければ空リスト返却
             return ret;
         }
         // javascriptでは32bit以上の数値をビットシフトできないため
         // 数値を10bit毎に分割してから計算する
-        const dec = parseInt(data, 16);
+        const dec = parseInt(fixedLengthData, 16);
         const bin = dec.toString(2);
         const dec1 = parseInt(bin.substr(0, 10), 2);
         const dec2 = parseInt(bin.substr(10, 10), 2);

--- a/urd/urd-ac-1ch.js
+++ b/urd/urd-ac-1ch.js
@@ -21,13 +21,17 @@ module.exports = class UrdAC1ch extends SensorInterface {
      * 電流計算およびcontentDataの生成.
      */
     static process(data, contentDataConfig) {
-        if (typeof data === 'undefined' || data.length < 4 * 2) {
+        const dataLength = 8; // 4Byte * 2
+
+        if (typeof data === 'undefined' || data.replace('0x', '').length < dataLength) {
             // 4Byte以上でなければ送信対象外のデータとし、sendFlg: falseのデータを返却
             return { contentData: [], message: '', sendFlg: false };
         }
 
+        // 処理に必要なデータ長を抽出
+        const fixedLengthData = data.replace('0x', '').slice(0, dataLength);
         // Decode to decimal value. ex. 'FFF' => 4095
-        const dec = parseInt(data, 16);
+        const dec = parseInt(fixedLengthData, 16);
         // eslint-disable-next-line no-bitwise
         const adVal = (dec >> 8) & 0b1111111111;
 

--- a/urd/urd-ac-3ch.js
+++ b/urd/urd-ac-3ch.js
@@ -22,6 +22,7 @@ module.exports = class UrdAC3ch extends SensorInterface {
      * 電流計算およびcontentDataの生成.
      */
     static process(serialData, contentDataConfig) {
+        const dataLength = 10; // 5Byte * 2
         const presetRange = {
             WLS50: 400,
             WLS100: 400,
@@ -31,17 +32,17 @@ module.exports = class UrdAC3ch extends SensorInterface {
 
         let message = '';
 
-        // 16進数表記から0xを除外
-        const serialDataString = serialData.replace('0x', '');
-        if (typeof serialData === 'undefined' || serialDataString.length < 5 * 2) {
+        if (typeof serialData === 'undefined' || serialData.replace('0x', '').length < dataLength) {
             // 5Byte以上でなければ送信対象外のデータとし、sendFlg: falseのデータを返却
             return { contentData: [], message, sendFlg: false };
         }
 
+        // 処理に必要なデータ長を抽出
+        const fixedLengthData = serialData.replace('0x', '').slice(0, dataLength);
         // contentDataの生成
         const contentData = contentDataConfig.slice(0, 3).map((dItem, index) => {
             // Decode to decimal value. ex. 'FFF' => 4095
-            const dec = parseInt(serialDataString.substr(index * 3, 3), 16);
+            const dec = parseInt(fixedLengthData.substr(index * 3, 3), 16);
 
             if (dItem.clampType === 'unconnected') {
                 // センサー未設定としたチャンネルに測定値(最大値以外)がある場合に警告メッセージを追加


### PR DESCRIPTION
EXTパターンのEnOceanデータのデータ長の固定化(5bit)を解除、
および各EnOcean設定ノード上で必要なデータ長を取り込むよう変更いたします。
ちなみにシグナルウォッチャーは変更の必要はありません。