### PR TITLE
fixup variable name on Modbus-com.js

### DIFF
--- a/PLC-Nodes/Modbus-com.js
+++ b/PLC-Nodes/Modbus-com.js
@@ -36,7 +36,7 @@ class ModbusCom extends PLCCom {
 
         if (!mbObj.isOpen && !(config.comType === "PLCSim")) {
             if (config.comType === "TCP") {
-                await mbObj.connectTCP(config.IPAdd, {port: Number(config.TCPport)})
+                await mbObj.connectTCP(config.IPAdd, {port: Number(config.TCPPort)})
                 .then(mbObj.setID(Number(config.unitID)));
             }
             else {


### PR DESCRIPTION
Capitalization errors started throwing errors after node.js ver. up
(Is is worked at node.js v16.x)